### PR TITLE
Fix typos in Readme and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Op-Rabbit is a high-level, opinionated, composable, fault-tolerant library for i
     - Messages published will wait for a connection to be available
 - Integration
     - Connection settings pulled from Typesafe config library
-    - Asyncronous, concurrent consumption using Scala native Futures or the new Akka Streams project.
+    - Asynchronous, concurrent consumption using Scala native Futures or the new Akka Streams project.
     - Common pattern for serialization allows easy integration with serialization libraries such play-json or json4s
     - Common pattern for exception handling to publish errors to Airbrake, Syslog, or all of the above
 - Modular
     - Composition favored over inheritance enabling flexible and high code reuse.
 - Modeled
     - Queue binding, exchange binding modeled with case classes
-    - Publishing mechansims also modeled
+    - Publishing mechanisms also modeled
 - Reliability
     - Builds on the excellent [Akka RabbitMQ client](https://github.com/thenewmotion/akka-rabbitmq) library for easy recovery.
     - Built-in consumer error recovery strategy in which messages are re-delivered to the message queue and retried (not implemented for akka-streams integration as retry mechanism affects message order)

--- a/core/src/main/scala/com/spingo/op_rabbit/consumer/RecoveryStrategy.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/consumer/RecoveryStrategy.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 /**
   Instructs rabbitmq what to do when an unhandled exceptions occur; by default, simply nack the message.
 
-  By contract, RecoveryStrategy returns a Future[Boolean], which is interpretted as follows:
+  By contract, RecoveryStrategy returns a Future[Boolean], which is interpreted as follows:
 
   - Success(true) acks the message, consumer continues with it's business
   - Success(false) nacks the message, consumer continues with it's business

--- a/core/src/main/scala/com/spingo/op_rabbit/consumer/binding.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/consumer/binding.scala
@@ -96,7 +96,7 @@ case class QueueBindingPassive(queueName: String) extends Binding {
 
   The op-rabbit Header properties class is modeled, such that the
   compiler will not allow you to specify a type that RabbitMQ does not
-  suport. Scala maps / seqs are appropriately converted.
+  support. Scala maps / seqs are appropriately converted.
 
   @param queueName    The name of the message queue to declare; the consumer paired with this binding will pull from this.
   @param exchangeName The name of the fanout exchange; idempotently declared.


### PR DESCRIPTION
just fixing some typos in documentation and Readme
