### PR TITLE
Remove hard dependency on Logback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,20 +279,20 @@ If you can see the pattern here, combining an akka-stream rabbitmq consumer and 
 
 ### Error notification
 
-It's important to know when your consumers fail. Out of the box, `op-rabbit` ships with support for logging to `logback` (and therefore syslog), and also `airbrake` via `op-rabbit-airbrake`. Without any additional signal provided by you, logback will be used, making error visibility a default.
+It's important to know when your consumers fail. Out of the box, `op-rabbit` ships with support for logging to `slf4j` (and therefore syslog), and also `airbrake` via `op-rabbit-airbrake`. Without any additional signal provided by you, slf4j will be used, making error visibility a default.
 
-You can report errors to multiple sources by combining error logging strategies; for example, if you'd like to report to both `logback` and to `airbrake`, import / set the following implicit RabbitErrorLogging in the scope where your consumer is instantiated:
+You can report errors to multiple sources by combining error logging strategies; for example, if you'd like to report to both `slf4j` and to `airbrake`, import / set the following implicit RabbitErrorLogging in the scope where your consumer is instantiated:
 
 ```scala
-import com.spingo.op_rabbit.{LogbackLogger, AirbrakeLogger}
+import com.spingo.op_rabbit.{Slf4jLogger, AirbrakeLogger}
 
-implicit val rabbitErrorLogging = LogbackLogger + AirbrakeLogger.fromConfig
+implicit val rabbitErrorLogging = Slf4jLogger + AirbrakeLogger.fromConfig
 ```
 
-Implementing your own error reporting strategy is simple; here's the source code for the LogbackLogger:
+Implementing your own error reporting strategy is simple; here's the source code for the slf4jLogger:
 
 ```scala
-object LogbackLogger extends RabbitErrorLogging {
+object Slf4jLogger extends RabbitErrorLogging {
   def apply(name: String, message: String, exception: Throwable, consumerTag: String, envelope: Envelope, properties: BasicProperties, body: Array[Byte]): Unit = {
     val logger = LoggerFactory.getLogger(name)
     logger.error(s"${message}. Body=${bodyAsString(body, properties)}. Envelope=${envelope}", exception)

--- a/build.sbt
+++ b/build.sbt
@@ -29,8 +29,10 @@ val commonSettings = Seq(
     "com.typesafe" % "config" % "1.3.0",
     "com.typesafe.akka"     %%  "akka-actor"   % akkaVersion,
     "com.typesafe.akka"     %%  "akka-testkit" % akkaVersion % "test",
+    "com.typesafe.akka"     %%  "akka-slf4j"   % akkaVersion % "test",
     "com.thenewmotion.akka" %% "akka-rabbitmq" % "1.2.7",
-    "ch.qos.logback" % "logback-classic" % "1.1.2",
+    "org.slf4j" % "slf4j-api" % "1.7.12",
+    "ch.qos.logback" % "logback-classic" % "1.1.3" % "test",
     "org.scalatest" %% "scalatest" % "2.2.1" % "test",
     "com.spingo" %% "scoped-fixtures" % "1.0.0" % "test"
   ),

--- a/core/root-doc.txt
+++ b/core/root-doc.txt
@@ -158,17 +158,17 @@ val received = (rabbitControl ? QueueMessage(Person(name = "Ivanah Tinkle", age 
 
 == Error Notification ==
 
-It's important to know when your consumers fail. Out of the box, `op-rabbit` ships with support for logging to `logback` (and therefore syslog) via [[com.spingo.op_rabbit.LogbackLogger LogbackLogger]], and also `airbrake` via `op-rabbit-airbrake`. Without any additional signal provided by you, logback will be used, making error visibility a default.
+It's important to know when your consumers fail. Out of the box, `op-rabbit` ships with support for logging to `slf4j` (and therefore syslog) via [[com.spingo.op_rabbit.slf4jLogger slf4jLogger]], and also `airbrake` via `op-rabbit-airbrake`. Without any additional signal provided by you, slf4j will be used, making error visibility a default.
 
-You can report errors to multiple sources by combining error logging strategies; for example, if you'd like to report to both `logback` and to `airbrake`, import / set the following implicit RabbitErrorLogging in the scope where your consumer is instantiated:
+You can report errors to multiple sources by combining error logging strategies; for example, if you'd like to report to both `slf4j` and to `airbrake`, import / set the following implicit RabbitErrorLogging in the scope where your consumer is instantiated:
 
 {{{
-import com.spingo.op_rabbit.{LogbackLogger, RabbitControl}
+import com.spingo.op_rabbit.{Slf4jLogger, RabbitControl}
 
-implicit val rabbitErrorLogging = LogbackLogger + AirbrakeLogger.fromConfig
+implicit val rabbitErrorLogging = Slf4jLogger + AirbrakeLogger.fromConfig
 }}}
 
-Implementing your own error reporting strategy is simple; see [[com.spingo.op_rabbit.LogbackLogger]]:
+Implementing your own error reporting strategy is simple; see [[com.spingo.op_rabbit.slf4jLogger]]:
 
 == Authors ==
 

--- a/core/src/main/scala/com/spingo/op_rabbit/RabbitErrorLogging.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/RabbitErrorLogging.scala
@@ -51,9 +51,9 @@ private class CombinedLogger(a: RabbitErrorLogging, b: RabbitErrorLogging) exten
 }
 
 /**
-  Reports consumer errors to Logback.
+  Reports consumer errors to Slf4j.
   */
-object LogbackLogger extends RabbitErrorLogging {
+object Slf4jLogger extends RabbitErrorLogging {
   def apply(name: String, context: String, exception: Throwable, consumerTag: String, envelope: Envelope, properties: BasicProperties, body: Array[Byte]): Unit = {
     val logger = LoggerFactory.getLogger(name)
     logger.error(s"${context}. Body=${bodyAsString(body, properties)}. Envelope=${envelope}", exception)
@@ -81,5 +81,5 @@ object RabbitErrorLogging {
     }
   }
 
-  implicit val defaultLogger: RabbitErrorLogging = LogbackLogger
+  implicit val defaultLogger: RabbitErrorLogging = Slf4jLogger
 }

--- a/core/src/test/resources/application.conf
+++ b/core/src/test/resources/application.conf
@@ -1,7 +1,7 @@
 op-rabbit {
   topic-exchange-name = "op-rabbit-testeroni"
   connection {
-    hosts = ["127.0.0.1"]
+    hosts = ["localhost"]
     username = "guest"
     password = "guest"
     connection-timeout = 1s
@@ -11,6 +11,8 @@ op-rabbit {
 
 akka {
   loglevel = "DEBUG"
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+
   actor {
     debug {
       # enable DEBUG logging of all LoggingFSMs for events, transitions and timers

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder>
+        <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %cyan(%logger{15}) - %msg%n%rootException</pattern>
+      </encoder>
+    </appender>
+
+    <logger level="DEBUG" name="com.spingo"/>
+
+    <logger level="INFO" name="akka"/>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
Libraries that utilize the Slf4j API should not have a transitive
dependency on any given logging binding. This commit replaces the
dependency on logback-classic with slf4j-api instead, and also
adds a bit of prettier logging to the test configuration.
