### PR TITLE
Allow Scala 2.10 / 2.11 cross-build in one branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ libraryDependencies ++= Seq(
 )
 ```
 
-### Version Compatibility Matrix:
+### Scala Version Compatibility Matrix:
 
-1.1.x
+2.11.x
 
 | module                       | dependsOn                | version  |
 | ---------------------------- | ------------------------ | -------- |
@@ -100,12 +100,12 @@ libraryDependencies ++= Seq(
 | op-rabbit-akka-steam-2.0-M2  | acked-stream             | 2.0-M2   |
 |                              | akka-stream-experimental | 2.0-M2   |
 
-1.0.x
+2.10.x
 
 | module                       | dependsOn                | version  |
 | ---------------------------- | ------------------------ | -------- |
-| op-rabbit-core               | akka                     | 2.2.x    |
-|                              | akka-rabbitmq            | 1.3.x    |
+| op-rabbit-core               | akka                     | 2.3.x    |
+|                              | akka-rabbitmq            | 2.x      |
 |                              | shapeless                | 2.2.x    |
 |                              | type-safe config         | >= 1.3.0 |
 | op-rabbit-play-json          | play-json                | 2.4.x    |


### PR DESCRIPTION
I already updated the akka-rabbitmq lib so that the latest version now builds for Scala 2.10 / Akka 2.3.14 as well as Scala 2.11 / Akka 2.41.

This PR updates op-rabbit to use the latest version of akka-rabbitmq and also pulls in the correct version of Akka based upon the Scala version.

Subsequently, you shouldn't need to maintain the v1.0.x branch anymore to provide Scala 2.10 and / or Akka 2.3 support (unless you plan to add Akka 2.4 specific features)
