### PR TITLE
Use Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: scala
+scala:
+  - 2.10.6
+  - 2.11.7
+jdk:
+  - oraclejdk8
+services:
+  - rabbitmq


### PR DESCRIPTION
This adds a configuration for enabling travis to run tests. Boots up a rabbitmq service and runs the tests on both scala 2.10.6 and 2.11.7.
