### PR TITLE
Fix artifact names in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ libraryDependencies ++= Seq(
 | op-rabbit-airbrake           | airbrake                 | 2.2.x    |
 | op-rabbit-akka-stream        | acked-stream             | 1.0      |
 |                              | akka-stream-experimental | 1.0      |
-| op-rabbit-akka-stream-2.0    | acked-stream             | 2.0      |
+| op-rabbit-akka-stream-2-0    | acked-stream             | 2.0      |
 |                              | akka-stream-experimental | 2.0.1    |
 
 2.10.x
@@ -113,7 +113,7 @@ libraryDependencies ++= Seq(
 | op-rabbit-airbrake           | airbrake                 | 2.2.x    |
 | op-rabbit-akka-stream        | acked-stream             | 1.0      |
 |                              | akka-stream-experimental | 1.0      |
-| op-rabbit-akka-stream-2.0    | acked-stream             | 2.0      |
+| op-rabbit-akka-stream-2-0    | acked-stream             | 2.0      |
 |                              | akka-stream-experimental | 2.0.1    |
 
 ## A high-level overview of the available components:


### PR DESCRIPTION
Akka streams 2.0 - compatible modules have wrong names in readme, this is confusing
