### PR TITLE
Fix typo in example application.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ op-rabbit {
     password = "guest"
     port = 5672
     ssl = false
-    ceonnction-timeout = 3s
+    connection-timeout = 3s
   }
 }
 ```


### PR DESCRIPTION
It seems there's a typo in example `application.conf`; this patch changes `ceonnction-timeout` directive to`connection-timeout`.
