### PR TITLE
Upgraded circe to 0.7.0

### DIFF
--- a/addons/circe/src/main/scala/com/spingo/op_rabbit/CirceSupport.scala
+++ b/addons/circe/src/main/scala/com/spingo/op_rabbit/CirceSupport.scala
@@ -1,6 +1,5 @@
 package com.spingo.op_rabbit
 
-import cats.data.Xor
 import io.circe.{Decoder, Encoder}
 import io.circe.parser.decode
 import io.circe.syntax.EncoderOps
@@ -36,9 +35,9 @@ object CirceSupport {
             }
 
             decode[T](str) match {
-              case Xor.Left(error) =>
+              case Left(error) =>
                 throw InvalidFormat(str, error.getMessage)
-              case Xor.Right(v) =>
+              case Right(v) =>
                 v
             }
         }

--- a/addons/circe/src/test/scala/com/spingo/op_rabbit/CirceSupportSpec.scala
+++ b/addons/circe/src/test/scala/com/spingo/op_rabbit/CirceSupportSpec.scala
@@ -2,7 +2,6 @@ package com.spingo.op_rabbit
 
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
-import cats.data.Xor
 import io.circe.{Decoder, Encoder}
 import io.circe.parser.decode
 import io.circe.syntax.EncoderOps

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import java.util.Properties
 
 val json4sVersion = "3.4.0"
 
-val circeVersion = "0.5.0"
+val circeVersion = "0.7.0"
 
 val akkaVersion = "2.4.8"
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val assertNoApplicationConf = taskKey[Unit]("Makes sure application.conf isn't p
 
 val commonSettings = Seq(
   organization := "com.spingo",
-  version := appProperties.getProperty("version"),
+  version := appProperties.getProperty("version", "0.0.0-SNAPSHOT"),
   scalaVersion := "2.11.8",
   crossScalaVersions := Seq("2.11.8"),
   resolvers ++= Seq(


### PR DESCRIPTION
Cats (which Circe depends on) [removed Xor](https://github.com/typelevel/cats/blob/master/CHANGES.md#version-080) to move to using Either. This upgrades circe to the latest version and removes CirceSupport's dependence on Xor.