### PR TITLE
Parse AMQP URI to pickup RabbitMQ connection properties

### DIFF
--- a/core/src/main/scala/com/spingo/op_rabbit/ConnectionParams.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/ConnectionParams.scala
@@ -67,12 +67,12 @@ object ConnectionParams {
   private val DefaultConnectionTimeout = 10000 /* 10 seconds */
 
   private val UriParamPath = "uri"
-  private val HostsPramPath = "hosts"
-  private val PortPramPath = "port"
-  private val UsernamePramPath = "username"
-  private val PasswordPramPath = "password"
-  private val VirtualHostPramPath = "virtual-host"
-  private val SslPramPath = "ssl"
+  private val HostsParamPath = "hosts"
+  private val PortParamPath = "port"
+  private val UsernameParamPath = "username"
+  private val PasswordParamPath = "password"
+  private val VirtualHostParamPath = "virtual-host"
+  private val SslParamPath = "ssl"
   private val ConnectionTimeoutParamPath = "connection-timeout"
   private val ConnectionTimeoutParamName = "connection_timeout"
   private val HeartbeatParamName = "heartbeat"
@@ -90,15 +90,15 @@ object ConnectionParams {
   @deprecated(message = "The parameters configuration is deprecated if favor of the URL configuration", since = "2.1.1")
   private def fromParameters(config: Config): ConnectionParams = {
     val hosts = readHosts(config).toArray
-    val port = config.getInt(PortPramPath)
+    val port = config.getInt(PortParamPath)
 
     ConnectionParams(
       hosts = hosts.map { h => new Address(h, port) },
       connectionTimeout = config.getDuration(ConnectionTimeoutParamPath, java.util.concurrent.TimeUnit.MILLISECONDS).toInt,
-      username = config.getString(UsernamePramPath),
-      password = config.getString(PasswordPramPath),
-      virtualHost = config.getString(VirtualHostPramPath),
-      ssl = config.getBoolean(SslPramPath)
+      username = config.getString(UsernameParamPath),
+      password = config.getString(PasswordParamPath),
+      virtualHost = config.getString(VirtualHostParamPath),
+      ssl = config.getBoolean(SslParamPath)
     )
   }
 
@@ -138,12 +138,12 @@ object ConnectionParams {
   }
 
   private def readHosts(config: Config): Seq[String] = {
-    Try(config.getStringList(HostsPramPath).asScala).getOrElse(readCommaSeparatedHosts(config))
+    Try(config.getStringList(HostsParamPath).asScala).getOrElse(readCommaSeparatedHosts(config))
   }
 
   private def readCommaSeparatedHosts(config: Config): Seq[String] =
     config
-      .getString(HostsPramPath)
+      .getString(HostsParamPath)
       .split(",")
       .map(_.trim)
 

--- a/core/src/main/scala/com/spingo/op_rabbit/ConnectionParams.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/ConnectionParams.scala
@@ -70,7 +70,7 @@ object ConnectionParams {
     if (config.hasPath("uri")) fromUri(new URI(config.getString("uri"))) else fromParameters(config)
   }
 
-  @deprecated(message = "The parameters configuration is deprecated if favor of the URL configuration", since = "2018-04-05")
+  @deprecated(message = "The parameters configuration is deprecated if favor of the URL configuration", since = "2.1.0")
   private def fromParameters(config: Config): ConnectionParams = {
     val hosts = readHosts(config).toArray
     val port = config.getInt("port")

--- a/core/src/main/scala/com/spingo/op_rabbit/ConnectionParams.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/ConnectionParams.scala
@@ -70,7 +70,7 @@ object ConnectionParams {
   }
 
   private def fromParameters(config: Config): ConnectionParams = {
-    val hosts = readHosts(config).toArray(new Array[String](0))
+    val hosts = readHosts(config).toArray
     val port = config.getInt("port")
 
     ConnectionParams(

--- a/core/src/main/scala/com/spingo/op_rabbit/ConnectionParams.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/ConnectionParams.scala
@@ -158,11 +158,17 @@ object ConnectionParams {
         val value = par.substring(index + 1)
         key match {
           case ConnectionTimeoutParamName =>
-            resp.copy(connectionTimeout = value.toInt)
+            Try(resp.copy(connectionTimeout = value.toInt)).recover {
+              case _: NumberFormatException => throw new IllegalArgumentException(s"The URL parameter [$ConnectionTimeoutParamName] value should be integer")
+            }.get
           case HeartbeatParamName =>
-            resp.copy(heartbeat = value.toInt)
+            Try(resp.copy(heartbeat = value.toInt)).recover {
+              case _: NumberFormatException => throw new IllegalArgumentException(s"The URL parameter [$HeartbeatParamName] value should be integer")
+            }.get
           case ChannelMaxParamName =>
-            resp.copy(channelMax = value.toInt)
+            Try(resp.copy(channelMax = value.toInt)).recover {
+              case _: NumberFormatException => throw new IllegalArgumentException(s"The URL parameter [$ChannelMaxParamName] value should be integer")
+            }.get
           case AuthMechanismParamName =>
             resp.copy(authMechanism = string2DefaultSaslConfig(value))
           case _ =>

--- a/core/src/test/scala/com/spingo/op_rabbit/ConnectionParamsMultihostSpec.scala
+++ b/core/src/test/scala/com/spingo/op_rabbit/ConnectionParamsMultihostSpec.scala
@@ -1,8 +1,67 @@
 package com.spingo.op_rabbit
 
+import com.rabbitmq.client.Address
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import org.scalatest.{FunSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
 /**
   * Created by Anton Naumov on 05.10.17.
   */
-class ConnectionParamsMultihostSpec {
+class ConnectionParamsMultihostSpec extends FunSpec with Matchers {
+  private val defaultConfig = ConfigFactory.load("application.conf").getConfig("op-rabbit.connection")
+  private val hostsPath = "hosts"
 
+  private def makeConfig(hosts: String, baseConfig: Config): Config =
+    defaultConfig.withValue(hostsPath, ConfigValueFactory.fromAnyRef(hosts))
+
+  private def makeConfig(hosts: List[String], baseConfig: Config): Config =
+    defaultConfig.withValue(hostsPath, ConfigValueFactory.fromAnyRef(hosts.asJava))
+
+  describe("fromConfig constructor") {
+    describe("reading from artificially created config") {
+      it("accepts hosts as array of strings") {
+        val hosts = List("localhost", "github.com")
+        val config = makeConfig(hosts, defaultConfig)
+
+        assertHosts(config, hosts)
+      }
+
+      it("accepts hosts as comma-separated string") {
+        val hosts = List("localhost", "github.com")
+        val config = makeConfig(hosts.mkString(","), defaultConfig)
+
+        assertHosts(config, hosts)
+      }
+
+      it("trims extra whitespace in comma-separated list") {
+        val hosts = List("localhost", "github.com")
+        val config = makeConfig(hosts.map(str => " " + str + " ").mkString(","), defaultConfig)
+
+        assertHosts(config, hosts)
+      }
+    }
+
+    describe("reading from real config file") {
+      val expectedHosts = List("localhost", "127.0.0.1")
+      it("accepts hosts as array of strings") {
+        val config = ConfigFactory.load("config_fixtures/hosts.list.conf").getConfig("op-rabbit.connection")
+
+        assertHosts(config, expectedHosts)
+      }
+
+      it("accepts hosts as comma-separated string") {
+        val config = ConfigFactory.load("config_fixtures/hosts.comma_separated.conf").getConfig("op-rabbit.connection")
+
+        assertHosts(config, expectedHosts)
+      }
+    }
+  }
+
+  private def assertHosts(config: Config, expectedHosts: List[String]) = {
+    val connectionParams = ConnectionParams.fromConfig(config)
+    val expectedPort = config.getInt("port")
+    connectionParams.hosts should contain theSameElementsAs expectedHosts.map(host => new Address(host, expectedPort))
+  }
 }

--- a/core/src/test/scala/com/spingo/op_rabbit/ConnectionParamsMultihostSpec.scala
+++ b/core/src/test/scala/com/spingo/op_rabbit/ConnectionParamsMultihostSpec.scala
@@ -6,9 +6,6 @@ import org.scalatest.{FunSpec, Matchers}
 
 import scala.collection.JavaConverters._
 
-/**
-  * Created by Anton Naumov on 05.10.17.
-  */
 class ConnectionParamsMultihostSpec extends FunSpec with Matchers {
   private val defaultConfig = ConfigFactory.load("application.conf").getConfig("op-rabbit.connection")
   private val hostsPath = "hosts"

--- a/core/src/test/scala/com/spingo/op_rabbit/ConnectionParamsSpec.scala
+++ b/core/src/test/scala/com/spingo/op_rabbit/ConnectionParamsSpec.scala
@@ -1,0 +1,67 @@
+package com.spingo.op_rabbit
+
+import com.rabbitmq.client.Address
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import org.scalatest.{FunSpec, Matchers}
+
+
+import scala.collection.JavaConversions._
+/**
+  * Created by Anton Naumov on 19.08.17.
+  */
+class ConnectionParamsSpec extends FunSpec with Matchers {
+  private val defaultConfig = ConfigFactory.load()
+  private val connectionPath = "op-rabbit.connection"
+
+  describe("fromConfig constructor") {
+    describe("original properties connection configuration") {
+      it("compose configuration parameters") {
+        val params = ConnectionParams.fromConfig(defaultConfig.getConfig(connectionPath))
+
+        params.hosts should contain theSameElementsAs Seq(new Address("localhost", 5672))
+        params.username should equal("guest")
+        params.password should equal("guest")
+        params.connectionTimeout should equal(1000)
+        params.ssl shouldBe false
+      }
+    }
+
+    describe("URI configuration parameters") {
+      it("compose single host configuration") {
+        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqp://user:secret@localhost:5672/vhost")))
+        val params = ConnectionParams.fromConfig(config.getConfig(connectionPath))
+
+        params.hosts should contain theSameElementsAs Seq(new Address("localhost", 5672))
+        params.username should equal("user")
+        params.password should equal("secret")
+        params.connectionTimeout should equal(10000)
+        params.ssl shouldBe false
+        params.virtualHost should equal("vhost")
+      }
+
+      it("compose multiple host configuration") {
+        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqp://user:secret@localhost:5672,127.0.0.1:5672/vhost")))
+        val params = ConnectionParams.fromConfig(config.getConfig(connectionPath))
+
+        params.hosts should contain theSameElementsAs Seq(new Address("localhost", 5672), new Address("127.0.0.1", 5672))
+        params.username should equal("user")
+        params.password should equal("secret")
+        params.connectionTimeout should equal(10000)
+        params.ssl shouldBe false
+        params.virtualHost should equal("vhost")
+      }
+
+      it("compose multiple host configuration with TLS protection") {
+        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqps://user:secret@localhost:5672,127.0.0.1:5672/vhost")))
+        val params = ConnectionParams.fromConfig(config.getConfig(connectionPath))
+
+        params.hosts should contain theSameElementsAs Seq(new Address("localhost", 5672), new Address("127.0.0.1", 5672))
+        params.username should equal("user")
+        params.password should equal("secret")
+        params.connectionTimeout should equal(10000)
+        params.ssl shouldBe true
+        params.virtualHost should equal("vhost")
+      }
+    }
+  }
+}

--- a/core/src/test/scala/com/spingo/op_rabbit/ConnectionParamsUriSpec.scala
+++ b/core/src/test/scala/com/spingo/op_rabbit/ConnectionParamsUriSpec.scala
@@ -1,15 +1,14 @@
 package com.spingo.op_rabbit
 
 import com.rabbitmq.client.Address
-import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.scalatest.{FunSpec, Matchers}
 
 import scala.collection.JavaConversions._
 
-class ConnectionParamsSpec extends FunSpec with Matchers {
+class ConnectionParamsUriSpec extends FunSpec with Matchers {
   private val defaultConfig = ConfigFactory.load()
   private val connectionPath = "op-rabbit.connection"
-  private val hostsPath = "hosts"
 
   describe("fromConfig constructor") {
     describe("original properties connection configuration") {
@@ -61,57 +60,5 @@ class ConnectionParamsSpec extends FunSpec with Matchers {
         params.virtualHost should equal("vhost")
       }
     }
-  }
-
-  private def makeConfig(hosts: String, baseConfig: Config): Config =
-    defaultConfig.withValue(hostsPath, ConfigValueFactory.fromAnyRef(hosts))
-
-  private def makeConfig(hosts: List[String], baseConfig: Config): Config =
-    defaultConfig.withValue(hostsPath, ConfigValueFactory.fromAnyRef(hosts))
-
-  describe("fromConfig constructor") {
-    describe("reading from artificially created config") {
-      it("accepts hosts as array of strings") {
-        val hosts = List("localhost", "github.com")
-        val config = makeConfig(hosts, defaultConfig)
-
-        assertHosts(config, hosts)
-      }
-
-      it("accepts hosts as comma-separated string") {
-        val hosts = List("localhost", "github.com")
-        val config = makeConfig(hosts.mkString(","), defaultConfig)
-
-        assertHosts(config, hosts)
-      }
-
-      it("trims extra whitespace in comma-separated list") {
-        val hosts = List("localhost", "github.com")
-        val config = makeConfig(hosts.map(str => " " + str + " ").mkString(","), defaultConfig)
-
-        assertHosts(config, hosts)
-      }
-    }
-
-    describe("reading from real config file") {
-      val expectedHosts = List("localhost", "127.0.0.1")
-      it("accepts hosts as array of strings") {
-        val config = ConfigFactory.load("config_fixtures/hosts.list.conf").getConfig("op-rabbit.connection")
-
-        assertHosts(config, expectedHosts)
-      }
-
-      it("accepts hosts as comma-separated string") {
-        val config = ConfigFactory.load("config_fixtures/hosts.comma_separated.conf").getConfig("op-rabbit.connection")
-
-        assertHosts(config, expectedHosts)
-      }
-    }
-  }
-
-  private def assertHosts(config: Config, expectedHosts: List[String]) = {
-    val connectionParams = ConnectionParams.fromConfig(config)
-    val expectedPort = config.getInt("port")
-    connectionParams.hosts should contain theSameElementsAs expectedHosts.map(host => new Address(host, expectedPort))
   }
 }

--- a/core/src/test/scala/com/spingo/op_rabbit/ConnectionParamsUriSpec.scala
+++ b/core/src/test/scala/com/spingo/op_rabbit/ConnectionParamsUriSpec.scala
@@ -55,9 +55,26 @@ class ConnectionParamsUriSpec extends FunSpec with Matchers {
         params.hosts should contain theSameElementsAs Seq(new Address("localhost", 5672), new Address("127.0.0.1", 5672))
         params.username should equal("user")
         params.password should equal("secret")
-        params.connectionTimeout should equal(10000)
         params.ssl shouldBe true
         params.virtualHost should equal("vhost")
+        params.connectionTimeout should equal(10000)
+        params.requestedHeartbeat should equal(60)
+        params.requestedChannelMax should equal(0)
+      }
+
+      it("compose multiple host configuration with TLS protection and additional URL parameters") {
+        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqps://user:secret@localhost:5672,127.0.0.1:5672/vhost?connection_timeout=20000&heartbeat=30&channel_max=2&auth_mechanism=external")))
+        val params = ConnectionParams.fromConfig(config.getConfig(connectionPath))
+
+        params.hosts should contain theSameElementsAs Seq(new Address("localhost", 5672), new Address("127.0.0.1", 5672))
+        params.username should equal("user")
+        params.password should equal("secret")
+        params.ssl shouldBe true
+        params.virtualHost should equal("vhost")
+        params.connectionTimeout should equal(20000)
+        params.requestedHeartbeat should equal(30)
+        params.requestedChannelMax should equal(2)
+        params.saslConfig.getSaslMechanism(Array("EXTERNAL")).getName should equal("EXTERNAL")
       }
     }
   }


### PR DESCRIPTION
I've been using RabbitMQ three years in the raw and find quite useful to configure all things in the one URI. Please take a look at the pull request, this is the basics implementation. It possible to extends it to tune additional parameters
