### PR TITLE
feat: make exchange types extensible for plugins

### DIFF
--- a/core/src/main/scala/com/spingo/op_rabbit/Directives.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/Directives.scala
@@ -1,11 +1,14 @@
 package com.spingo.op_rabbit
 
 import com.spingo.op_rabbit.properties.PropertyExtractor
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.implicitConversions
 import shapeless._
 import com.spingo.op_rabbit.Binding._
-import scala.util.{Try,Failure,Success}
+import com.spingo.op_rabbit.Exchange.ExchangeType
+
+import scala.util.{Failure, Success, Try}
 
 protected class TypeHolder[T] {}
 protected object TypeHolder {
@@ -114,7 +117,7 @@ trait Directives {
   def passive[T <: Concreteness](queue: QueueDefinition[T]): QueueDefinition[T] =
     Queue.passive(queue)
 
-  def passive[T <: Exchange.Value](exchange: Exchange[T]): Exchange[T] =
+  def passive[T <: ExchangeType](exchange: Exchange[T]): Exchange[T] =
     Exchange.passive(exchange)
 
   def as[T](implicit um: RabbitUnmarshaller[T]) = um


### PR DESCRIPTION
Add an abstract class ExchangeType to replace Exchange Enumeration values and let library users extend exchange type for plugins like [rabbitmq-consistent-hash-exchange](https://github.com/rabbitmq/rabbitmq-consistent-hash-exchange).

It then makes it easy to create specific binding outside of the library like this for different plugins

```scala
case object ConsistentHash extends ExchangeType("x-consistent-hash")

def consistentHash(queue: QueueDefinition[Concrete],
                   hashSpacePoints: Int,
                   exchange: ExchangeDefinition[Concrete] with Exchange[ConsistentHash.type]): Binding = new Binding {
    val exchangeName = exchange.exchangeName
    val queueName = queue.queueName
    def declare(c: Channel): Unit = {
      exchange.declare(c)
      queue.declare(c)
      c.queueBind(queueName, exchange.exchangeName, hashSpacePoints.toString, null)
    }
}
```

and use it seamlessly with the existing DSL

```scala
consume(consistentHash(queue("queue.name"), 20, Exchange.plugin(ConsistentHash, "exchange.name")))
```