### PR TITLE
Upgrade to Circe 0.9.0 for working with cats 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import java.util.Properties
 
 val json4sVersion = "3.5.1"
 
-val circeVersion = "0.7.0"
+val circeVersion = "0.9.0"
 
 val akkaVersion = "2.4.17"
 
@@ -21,8 +21,8 @@ val assertNoApplicationConf = taskKey[Unit]("Makes sure application.conf isn't p
 val commonSettings = Seq(
   organization := "com.spingo",
   version := appProperties.getProperty("version"),
-  scalaVersion := "2.11.8",
-  crossScalaVersions := Seq("2.11.8", "2.12.1"),
+  scalaVersion := "2.11.11",
+  crossScalaVersions := Seq("2.11.11", "2.12.4"),
   libraryDependencies ++= Seq(
     "com.chuusai" %%  "shapeless" % "2.3.2",
     "com.typesafe" % "config" % "1.3.0",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.16


### PR DESCRIPTION
Hi, @timcharper Many thanks for your open source. :-)

[Upgrading Dependencies PR](https://github.com/SpinGo/op-rabbit/pull/129) already exists. But it includes `circe 0.8.0`. 
To work with [cats 1.0.0](https://typelevel.org/blog/2017/12/25/cats-1.0.0.html), we need to upgrade to [`circe 0.9.0`](https://github.com/circe/circe/releases/tag/v0.9.0). 😀

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spingo/op-rabbit/131)
<!-- Reviewable:end -->
