### PR TITLE
Boolean header reader

### DIFF
--- a/core/src/main/scala/com/spingo/op_rabbit/properties/HeaderValueConverter.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/properties/HeaderValueConverter.scala
@@ -164,6 +164,14 @@ object FromHeaderValue {
     }
   }
 
+  case class BooleanFromHeaderValue(charset: Charset = Charset.defaultCharset) extends FromHeaderValue[Boolean] {
+    val manifest = implicitly[Manifest[Boolean]]
+    def apply(hv: HeaderValue) = {
+      Right(hv.value.asInstanceOf[Boolean])
+    }
+  }
+
+  implicit val booleanHeaderConversion = BooleanFromHeaderValue()
   implicit val defaultStringConversion = StringFromHeaderValue()
   implicit val defaultByteConversion = ByteFromHeaderValue()
   implicit val defaultIntConversion = IntFromHeaderValue()

--- a/core/src/main/scala/com/spingo/op_rabbit/properties/HeaderValueConverter.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/properties/HeaderValueConverter.scala
@@ -167,7 +167,12 @@ object FromHeaderValue {
   case class BooleanFromHeaderValue(charset: Charset = Charset.defaultCharset) extends FromHeaderValue[Boolean] {
     val manifest = implicitly[Manifest[Boolean]]
     def apply(hv: HeaderValue) = {
-      Right(hv.value.asInstanceOf[Boolean])
+      try{
+        Right(hv.value.asInstanceOf[Boolean])
+      }
+      catch{
+        case cce: ClassCastException => Left(HeaderValueConversionException(s"Could not convert ${hv.value} to Boolean", cce))
+      }
     }
   }
 

--- a/core/src/test/scala/com/spingo/op_rabbit/properties/HeaderValueSpec.scala
+++ b/core/src/test/scala/com/spingo/op_rabbit/properties/HeaderValueSpec.scala
@@ -70,6 +70,10 @@ class HeaderValueSpec extends FunSpec with Matchers {
         HeaderValue(true).asOpt[Boolean] should be (Some(true))
         HeaderValue(false).asOpt[Boolean] should be (Some(false))
       }
+
+      it("Should fail in case of a wrong provided value"){
+        HeaderValue("1").asOpt[Boolean] should be (None)
+      }
     }
 
     describe("Seq") {

--- a/core/src/test/scala/com/spingo/op_rabbit/properties/HeaderValueSpec.scala
+++ b/core/src/test/scala/com/spingo/op_rabbit/properties/HeaderValueSpec.scala
@@ -65,6 +65,13 @@ class HeaderValueSpec extends FunSpec with Matchers {
       testNumeric[BigDecimal]("BigDecimal", BigDecimal(1))
     }
 
+    describe("Boolean"){
+      it("Should convert Boolean values to boolean"){
+        HeaderValue(true).asOpt[Boolean] should be (Some(true))
+        HeaderValue(false).asOpt[Boolean] should be (Some(false))
+      }
+    }
+
     describe("Seq") {
       it("extracts a Seq[Int] when all members can be converted") {
         HeaderValue(Seq("1", "2", "3")).asOpt[Seq[Int]] should be (Some(Seq(1,2,3)))


### PR DESCRIPTION
We've faced a case in where we needed to read a `Boolean` header from RabbitMQ. When you try to read a Boolean header like this:

```
Subscription {
      channel(qos){
        consume(queue(
          queueID,
          durable = true,
          exclusive = false,
          autoDelete = false
        )) {
          (body(as[String]) & routingKey & property(TypedHeader[String]("prop1")) & property(TypedHeader[Boolean]("prop2"))){...}
```

You get this error:

`could not find implicit value for parameter conversion: com.spingo.op_rabbit.properties.FromHeaderValue[Boolean]`

Because op-rabbit doesn't have an implementation for reading this type.
We've written this solution for our problem and it works great.

The only thing that I don't like (but I think that there's no other way, and if there's actually a different method to do it, please point it out for me) is the usage of `asInstanceOf`, but, being the `value` of the `HeaderValue` an `Any`, I can't find another way of doing this.

I hope that this could useful for someone else @DStranger :)

Thank you!