### PR TITLE
make code more Scala 2.13 friendly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 dist: trusty
 
 scala:
-  - 2.12.5
+  - 2.12.6
   - 2.11.12
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ scala:
   - 2.11.12
 
 jdk:
-  - oraclejdk7
-  - oraclejdk8
+  - openjdk7
+  - openjdk8
 
 # inspired by https://github.com/hashicorp/nomad-scala-sdk/blob/master/.travis.yml
 matrix:
   exclude:
   # We build Scala 2.11 on Java 7, so let's not bother with Java 8
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     scala: 2.11.12
-  - jdk: oraclejdk7
+  - jdk: openjdk7
     scala: 2.13.0
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: scala
 
+services:
+  - rabbitmq
+
+sudo: false
+
 scala:
   - 2.12.8
   - 2.11.12
@@ -15,12 +20,7 @@ matrix:
   - jdk: openjdk8
     scala: 2.11.12
   - jdk: openjdk7
-    scala: 2.13.0
-
-services:
-  - rabbitmq
-
-sudo: false
+    scala: 2.12.8
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 
 scala:
   - 2.12.6
-  - 2.11.12
 
 jdk:
   - oraclejdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - 2.12.6
+  - 2.12.8
   - 2.11.12
 
 jdk:
@@ -14,6 +14,8 @@ matrix:
   # We build Scala 2.11 on Java 7, so let's not bother with Java 8
   - jdk: oraclejdk8
     scala: 2.11.12
+  - jdk: oraclejdk7
+    scala: 2.13.0
 
 services:
   - rabbitmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ language: scala
 dist: trusty
 
 scala:
-  - 2.12.10
+  - 2.12.5
   - 2.11.12
 
 jdk:
-  - oraclejdk8
   - oraclejdk11
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: scala
 dist: trusty
 
 scala:
-  - 2.13.1
   - 2.12.10
   - 2.11.12
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import java.util.Properties
 val json4sVersion = "3.6.6"
 val circeVersion = "0.12.0-M3"
 val akkaVersion = "2.5.23"
-val playVersion = "2.7.3"
+val playVersion = "2.7.4"
 
 val appProperties = {
   val prop = new Properties()

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ val commonSettings = Seq(
   organization := "com.spingo",
   version := appProperties.getProperty("version"),
   scalaVersion := "2.12.6",
-  crossScalaVersions := Seq("2.12.6", "2.11.12", "2.13.0"),
+  crossScalaVersions := Seq("2.12.6", "2.13.0"),
   libraryDependencies ++= Seq(
     "com.chuusai" %%  "shapeless" % "2.3.3",
     "com.typesafe" % "config" % "1.3.4",

--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,7 @@ lazy val `spray-json` = (project in file("./addons/spray-json")).
   settings(commonSettings: _*).
   settings(
     name := "op-rabbit-spray-json",
-    libraryDependencies += "io.spray" %% "spray-json" % "1.3.4").
+    libraryDependencies += "io.spray" %% "spray-json" % "1.3.5").
   dependsOn(core)
 
 lazy val airbrake = (project in file("./addons/airbrake/")).

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import java.util.Properties
 
 val json4sVersion = "3.6.6"
-val circeVersion = "0.12.0-M3"
-val akkaVersion = "2.5.23"
+val circeVersion = "0.12.3"
+val akkaVersion = "2.5.25"
 val playVersion = "2.7.4"
 
 val appProperties = {
@@ -16,8 +16,8 @@ val assertNoApplicationConf = taskKey[Unit]("Makes sure application.conf isn't p
 val commonSettings = Seq(
   organization := "com.spingo",
   version := appProperties.getProperty("version"),
-  scalaVersion := "2.12.8",
-  crossScalaVersions := Seq("2.12.8", "2.11.12", "2.13.0"),
+  scalaVersion := "2.12.6",
+  crossScalaVersions := Seq("2.12.6", "2.11.12", "2.13.0"),
   libraryDependencies ++= Seq(
     "com.chuusai" %%  "shapeless" % "2.3.3",
     "com.typesafe" % "config" % "1.3.4",

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "com.chuusai" %%  "shapeless" % "2.3.3",
     "com.typesafe" % "config" % "1.3.4",
-    "com.newmotion" %% "akka-rabbitmq" % "5.0.0",
+    "com.newmotion" %% "akka-rabbitmq" % "5.1.1",
     "org.slf4j" % "slf4j-api" % "1.7.26",
     "ch.qos.logback" % "logback-classic" % "1.2.3" % "test",
     "org.scalatest" %% "scalatest" % "3.0.8" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 import java.util.Properties
 
-val json4sVersion = "3.5.3"
-val circeVersion = "0.9.0"
-val akkaVersion = "2.5.9"
-val playVersion = "2.6.10"
+val json4sVersion = "3.6.6"
+val circeVersion = "0.12.0-M3"
+val akkaVersion = "2.5.23"
+val playVersion = "2.7.3"
 
 val appProperties = {
   val prop = new Properties()
@@ -16,15 +16,15 @@ val assertNoApplicationConf = taskKey[Unit]("Makes sure application.conf isn't p
 val commonSettings = Seq(
   organization := "com.spingo",
   version := appProperties.getProperty("version"),
-  scalaVersion := "2.12.6",
-  crossScalaVersions := Seq("2.12.6", "2.11.12"),
+  scalaVersion := "2.12.8",
+  crossScalaVersions := Seq("2.12.8", "2.11.12", "2.13.0"),
   libraryDependencies ++= Seq(
     "com.chuusai" %%  "shapeless" % "2.3.3",
-    "com.typesafe" % "config" % "1.3.2",
+    "com.typesafe" % "config" % "1.3.4",
     "com.newmotion" %% "akka-rabbitmq" % "5.0.0",
-    "org.slf4j" % "slf4j-api" % "1.7.25",
+    "org.slf4j" % "slf4j-api" % "1.7.26",
     "ch.qos.logback" % "logback-classic" % "1.2.3" % "test",
-    "org.scalatest" %% "scalatest" % "3.0.4" % "test",
+    "org.scalatest" %% "scalatest" % "3.0.8" % "test",
     "com.spingo" %% "scoped-fixtures" % "2.0.0" % "test",
     "com.typesafe.akka" %% "akka-actor" % akkaVersion,
     "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test",

--- a/core/src/main/scala/com/spingo/op_rabbit/ConnectionParams.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/ConnectionParams.scala
@@ -138,7 +138,7 @@ object ConnectionParams {
   }
 
   private def readHosts(config: Config): Seq[String] = {
-    Try(config.getStringList(HostsParamPath).asScala).getOrElse(readCommaSeparatedHosts(config))
+    Try(config.getStringList(HostsParamPath).asScala.toSeq).getOrElse(readCommaSeparatedHosts(config))
   }
 
   private def readCommaSeparatedHosts(config: Config): Seq[String] =

--- a/core/src/main/scala/com/spingo/op_rabbit/SubscriptionActor.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/SubscriptionActor.scala
@@ -196,7 +196,7 @@ private [op_rabbit] class SubscriptionActor(
 
       initialized.tryFailure(new RuntimeException("Subscription stopped before it had a chance to initialize"))
       closed.tryComplete(
-        payload.shutdownCause.map(Failure(_)).getOrElse(Success(Unit))
+        payload.shutdownCause.map(Failure(_)).getOrElse(Success(()))
       )
       stop()
   }

--- a/core/src/main/scala/com/spingo/op_rabbit/package.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/package.scala
@@ -8,5 +8,5 @@ package object op_rabbit {
   type Directive1[T] = Directive[::[T, HNil]]
   type Deserialized[T] = Either[Rejection.ExtractRejection, T]
 
-  protected val futureUnit: Future[Unit] = Future.successful(Unit)
+  protected val futureUnit: Future[Unit] = Future.successful(())
 }

--- a/core/src/test/scala/com/spingo/op_rabbit/ConnectionParamsUriSpec.scala
+++ b/core/src/test/scala/com/spingo/op_rabbit/ConnectionParamsUriSpec.scala
@@ -1,10 +1,10 @@
 package com.spingo.op_rabbit
 
-import com.rabbitmq.client.Address
+import com.rabbitmq.client.{Address, ConnectionFactory}
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.scalatest.{FunSpec, Matchers}
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class ConnectionParamsUriSpec extends FunSpec with Matchers {
   private val defaultConfig = ConfigFactory.load()
@@ -25,7 +25,7 @@ class ConnectionParamsUriSpec extends FunSpec with Matchers {
 
     describe("URI configuration parameters") {
       it("compose single host configuration") {
-        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqp://user:secret@localhost:5672/vhost")))
+        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqp://user:secret@localhost:5672/vhost").asJava))
         val params = ConnectionParams.fromConfig(config.getConfig(connectionPath))
 
         params.hosts should contain theSameElementsAs Seq(new Address("localhost", 5672))
@@ -37,7 +37,7 @@ class ConnectionParamsUriSpec extends FunSpec with Matchers {
       }
 
       it("compose single host configuration with default credentials") {
-        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqp://localhost:5672/vhost")))
+        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqp://localhost:5672/vhost").asJava))
         val params = ConnectionParams.fromConfig(config.getConfig(connectionPath))
 
         params.hosts should contain theSameElementsAs Seq(new Address("localhost", 5672))
@@ -49,7 +49,7 @@ class ConnectionParamsUriSpec extends FunSpec with Matchers {
       }
 
       it("compose multiple host configuration") {
-        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqp://user:secret@localhost:5672,127.0.0.1:5672/vhost")))
+        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqp://user:secret@localhost:5672,127.0.0.1:5672/vhost").asJava))
         val params = ConnectionParams.fromConfig(config.getConfig(connectionPath))
 
         params.hosts should contain theSameElementsAs Seq(new Address("localhost", 5672), new Address("127.0.0.1", 5672))
@@ -61,7 +61,7 @@ class ConnectionParamsUriSpec extends FunSpec with Matchers {
       }
 
       it("compose multiple host configuration with default credentials") {
-        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqp://localhost:5672,127.0.0.1:5672/vhost")))
+        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqp://localhost:5672,127.0.0.1:5672/vhost").asJava))
         val params = ConnectionParams.fromConfig(config.getConfig(connectionPath))
 
         params.hosts should contain theSameElementsAs Seq(new Address("localhost", 5672), new Address("127.0.0.1", 5672))
@@ -73,7 +73,7 @@ class ConnectionParamsUriSpec extends FunSpec with Matchers {
       }
 
       it("compose multiple host configuration with TLS protection") {
-        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqps://user:secret@localhost:5672,127.0.0.1:5672/vhost")))
+        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqps://user:secret@localhost:5672,127.0.0.1:5672/vhost").asJava))
         val params = ConnectionParams.fromConfig(config.getConfig(connectionPath))
 
         params.hosts should contain theSameElementsAs Seq(new Address("localhost", 5672), new Address("127.0.0.1", 5672))
@@ -83,11 +83,12 @@ class ConnectionParamsUriSpec extends FunSpec with Matchers {
         params.virtualHost should equal("vhost")
         params.connectionTimeout should equal(10000)
         params.requestedHeartbeat should equal(60)
-        params.requestedChannelMax should equal(0)
+        params.requestedChannelMax should equal(ConnectionFactory.DEFAULT_CHANNEL_MAX)
       }
 
       it("compose multiple host configuration with TLS protection and additional URL parameters") {
-        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqps://user:secret@localhost:5672,127.0.0.1:5672/vhost?connection_timeout=20000&heartbeat=30&channel_max=2&auth_mechanism=external")))
+        val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(
+          Map("uri" -> "amqps://user:secret@localhost:5672,127.0.0.1:5672/vhost?connection_timeout=20000&heartbeat=30&channel_max=2&auth_mechanism=external").asJava))
         val params = ConnectionParams.fromConfig(config.getConfig(connectionPath))
 
         params.hosts should contain theSameElementsAs Seq(new Address("localhost", 5672), new Address("127.0.0.1", 5672))
@@ -103,7 +104,8 @@ class ConnectionParamsUriSpec extends FunSpec with Matchers {
 
       it("failed to compose multiple host configuration with TLS protection and additional URL parameters cause unsupported parameter specified") {
         val e = intercept[IllegalArgumentException] {
-          val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqps://user:secret@localhost:5672,127.0.0.1:5672/vhost?connection_timeout=20000&heartbeat=30&channel_max=2&auth_mechanism=external&unsupported_parameter=1")))
+          val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(
+            Map("uri" -> "amqps://user:secret@localhost:5672,127.0.0.1:5672/vhost?connection_timeout=20000&heartbeat=30&channel_max=2&auth_mechanism=external&unsupported_parameter=1").asJava))
           ConnectionParams.fromConfig(config.getConfig(connectionPath))
         }
         e.getMessage should equal("The URL parameter [unsupported_parameter] is not supported")
@@ -111,7 +113,8 @@ class ConnectionParamsUriSpec extends FunSpec with Matchers {
 
       it("failed to compose multiple host configuration with TLS protection and additional URL parameters cause parameter value has incorrect format") {
         val e = intercept[IllegalArgumentException] {
-          val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqps://user:secret@localhost:5672,127.0.0.1:5672/vhost?connection_timeout=20000&heartbeat=30&channel_max=two&auth_mechanism=external")))
+          val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(
+            Map("uri" -> "amqps://user:secret@localhost:5672,127.0.0.1:5672/vhost?connection_timeout=20000&heartbeat=30&channel_max=two&auth_mechanism=external").asJava))
           ConnectionParams.fromConfig(config.getConfig(connectionPath))
         }
         e.getMessage should equal("The URL parameter [channel_max] value should be integer")
@@ -119,7 +122,8 @@ class ConnectionParamsUriSpec extends FunSpec with Matchers {
 
       it("failed to compose multiple host configuration with TLS protection and additional URL parameters cause auth mechanism incorrect value") {
         val e = intercept[IllegalArgumentException] {
-          val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqps://user:secret@localhost:5672,127.0.0.1:5672/vhost?connection_timeout=20000&heartbeat=30&channel_max=2&auth_mechanism=custom")))
+          val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(
+            Map("uri" -> "amqps://user:secret@localhost:5672,127.0.0.1:5672/vhost?connection_timeout=20000&heartbeat=30&channel_max=2&auth_mechanism=custom").asJava))
           ConnectionParams.fromConfig(config.getConfig(connectionPath))
         }
         e.getMessage should equal("The URL parameter [auth_mechanism] supports PLAIN or EXTERNAL values only")
@@ -127,7 +131,7 @@ class ConnectionParamsUriSpec extends FunSpec with Matchers {
 
       it("failed to compose multiple host configuration partial credentials") {
         val e = intercept[IllegalArgumentException] {
-          val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqps://user@localhost:5672,127.0.0.1:5672/vhost")))
+          val config = defaultConfig.withValue(connectionPath, ConfigValueFactory.fromMap(Map("uri" -> "amqps://user@localhost:5672,127.0.0.1:5672/vhost").asJava))
           ConnectionParams.fromConfig(config.getConfig(connectionPath))
         }
         e.getMessage should equal("The URL authority should contains user and password")

--- a/core/src/test/scala/com/spingo/op_rabbit/helpers/RabbitTestHelpers.scala
+++ b/core/src/test/scala/com/spingo/op_rabbit/helpers/RabbitTestHelpers.scala
@@ -9,8 +9,10 @@ import com.rabbitmq.client.Channel
 import com.spingo.op_rabbit.RabbitControl
 import com.spingo.op_rabbit.{MessageForPublicationLike, RabbitMarshaller, RabbitUnmarshaller}
 import com.spingo.scoped_fixtures.ScopedFixtures
+
 import scala.concurrent.{Await, Future, Promise}
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 trait RabbitTestHelpers extends ScopedFixtures {
   implicit val timeout = Timeout(5 seconds)

--- a/core/src/test/scala/com/spingo/op_rabbit/properties/packageSpec.scala
+++ b/core/src/test/scala/com/spingo/op_rabbit/properties/packageSpec.scala
@@ -1,10 +1,8 @@
 package com.spingo.op_rabbit.properties
 
 import org.scalatest.{FunSpec, Matchers}
-import com.spingo.op_rabbit.properties._
-import com.rabbitmq.client.impl.LongStringHelper
-import com.rabbitmq.client.AMQP.BasicProperties.Builder
-import com.rabbitmq.client.AMQP.BasicProperties
+
+import scala.language.postfixOps
 
 class PropertiesSpec extends FunSpec with Matchers {
   describe("Setting properties") {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.2.8


### PR DESCRIPTION
Some dependencies are not yet ready with scala 2.13 jars but these code changes get a lot of the way towards supporting scala 2.13.

Relates to https://github.com/SpinGo/op-rabbit/issues/171