### PR TITLE
Don't use ExecutionContext.global. Improve `ackableFromFuture` to handle future exceptions.

### DIFF
--- a/core/src/main/scala/com/spingo/op_rabbit/Directives.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/Directives.scala
@@ -242,12 +242,9 @@ object Directives extends Directives {
   case class Ackable(handler: Handler)
   object Ackable extends (Handler => Ackable) {
     implicit def ackableFromFuture(f: Future[_])(implicit ec: ExecutionContext) = Ackable({ (p, delivery) =>
-      p.completeWith(f.transform {
-        case Success(_) =>
-          Success(ReceiveResult.Ack(delivery))
-        case Failure(ex) =>
-          Success(ReceiveResult.Fail(delivery, None, ex))
-      })
+      p.completeWith(
+        f.map(_ => ReceiveResult.Ack(delivery)).recover { case ex => ReceiveResult.Fail(delivery, None, ex) }
+      )
     })
 
     implicit def ackableFromTry(t: Try[_]) = Ackable({ (p, delivery) =>


### PR DESCRIPTION
- Never hardcode a global execution context since this could cause problems
  with users having a custom execution context. Let the user provide it via implicit arg.

- `ackableFromFuture` now resolves with `RecieveResult.Fail` if the given
future is a failure, just like it is done on `ackableFromTry`