### PR TITLE
add more tls support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import java.util.Properties
 
 val json4sVersion = "3.6.6"
-val circeVersion = "0.12.0-M3"
+val circeVersion = "0.12.3"
 val akkaVersion = "2.5.25"
 val playVersion = "2.7.4"
 
@@ -16,7 +16,7 @@ val assertNoApplicationConf = taskKey[Unit]("Makes sure application.conf isn't p
 val commonSettings = Seq(
   organization := "com.spingo",
   version := appProperties.getProperty("version"),
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.12.10",
   crossScalaVersions := Seq("2.12.10", "2.13.1"),
   libraryDependencies ++= Seq(
     "com.chuusai" %%  "shapeless" % "2.3.3",

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import java.util.Properties
 
 val json4sVersion = "3.6.6"
-val circeVersion = "0.12.3"
+val circeVersion = "0.12.0-M3"
 val akkaVersion = "2.5.25"
 val playVersion = "2.7.4"
 
@@ -16,7 +16,7 @@ val assertNoApplicationConf = taskKey[Unit]("Makes sure application.conf isn't p
 val commonSettings = Seq(
   organization := "com.spingo",
   version := appProperties.getProperty("version"),
-  scalaVersion := "2.12.10",
+  scalaVersion := "2.11.8",
   crossScalaVersions := Seq("2.12.10", "2.13.1"),
   libraryDependencies ++= Seq(
     "com.chuusai" %%  "shapeless" % "2.3.3",

--- a/project/version.properties
+++ b/project/version.properties
@@ -1,1 +1,1 @@
-version=2.1.1-1
+version=2.1.2-msw

--- a/project/version.properties
+++ b/project/version.properties
@@ -1,1 +1,1 @@
-version=2.1.2-msw
+version=2.1.0

--- a/project/version.properties
+++ b/project/version.properties
@@ -1,1 +1,1 @@
-version=2.1.0
+version=2.1.1-1


### PR DESCRIPTION
The current support for op-rabbit allows to enable simple TLS only for dev/test mode(i.e. the underlying trust manager is a TrustEverythingTrustManager).

To overcome this, the op-rabbit's ConnectionParams constructor will gain at the end a new optional SSLContext with default value None. In this way, the backward compatibility is also provided.

By offering the op-rabbit client the possibility to specify  its own `SSLContext`, we decouple the client's specific config(i.e.  the client app might have already setup it's own keystore/truststore manager and also already initialized a SSLContext based on these) from op-rabbit connection config and hence it's more flexible.

The `ConnectionParams` remains backward compatible by adding a 
```
sslContextOpt: Option[SSLContext] = None
```
right at the end and also keeps the constructor coherent:

if ssl is true
- if sslContextOpt is Some(sslContext) then the `factory`  uses the client  `sslContext` 
- otherwise,  `factory` uses the default `SSLcontext` (i.e based on the underlying TrustEverythingTrustManager)
 















