### PR TITLE
Directives body opt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import java.util.Properties
 
 val json4sVersion = "3.6.6"
-val circeVersion = "0.12.0-M3"
+val circeVersion = "0.12.3"
 val akkaVersion = "2.5.25"
 val playVersion = "2.7.4"
 
@@ -16,7 +16,7 @@ val assertNoApplicationConf = taskKey[Unit]("Makes sure application.conf isn't p
 val commonSettings = Seq(
   organization := "com.spingo",
   version := appProperties.getProperty("version"),
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.12.10",
   crossScalaVersions := Seq("2.12.10", "2.13.1"),
   libraryDependencies ++= Seq(
     "com.chuusai" %%  "shapeless" % "2.3.3",

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import java.util.Properties
 
 val json4sVersion = "3.6.6"
-val circeVersion = "0.12.3"
+val circeVersion = "0.12.0-M3"
 val akkaVersion = "2.5.25"
 val playVersion = "2.7.4"
 
@@ -16,7 +16,7 @@ val assertNoApplicationConf = taskKey[Unit]("Makes sure application.conf isn't p
 val commonSettings = Seq(
   organization := "com.spingo",
   version := appProperties.getProperty("version"),
-  scalaVersion := "2.12.10",
+  scalaVersion := "2.11.8",
   crossScalaVersions := Seq("2.12.10", "2.13.1"),
   libraryDependencies ++= Seq(
     "com.chuusai" %%  "shapeless" % "2.3.3",

--- a/core/src/main/scala/com/spingo/op_rabbit/EnhancedTry.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/EnhancedTry.scala
@@ -1,0 +1,10 @@
+package com.spingo.op_rabbit
+
+import scala.util.{Success, Try}
+
+object EnhancedTry {
+  implicit class EnhancedTryImpl[T](t: Try[T]) {
+    def toEither: Either[Throwable, T] =
+      t.transform(success => Success(Right(success)), exception => Success(Left(exception))).get
+  }
+}

--- a/core/src/test/scala/com/spingo/op_rabbit/DirectivesSpec.scala
+++ b/core/src/test/scala/com/spingo/op_rabbit/DirectivesSpec.scala
@@ -107,6 +107,29 @@ class DirectivesSpec extends FunSpec with Matchers with Inside {
         }
       } should be (acked)
     }
+
+    it("yields the value for both directives when one is bodyEither") {
+      val delivery = testDelivery(body = "hi".getBytes, properties = Seq(ReplyTo("place")))
+      resultFor(delivery) {
+        (bodyEither(as[String]) & property(ReplyTo)) { (bodyEither, replyTo) =>
+          replyTo should be ("place")
+          bodyEither.right.get should be ("hi")
+          ack
+        }
+      } should be (acked)
+    }
+  }
+
+  describe("bodyEither") {
+    it("yields the value as an option") {
+      val delivery = testDelivery(body = "hi".getBytes)
+      resultFor(delivery) {
+        (bodyEither(as[String])) { (bodyEither) =>
+          bodyEither.right.get should be ("hi")
+          ack
+        }
+      } should be (acked)
+    }
   }
 
   describe("|") {

--- a/project/version.properties
+++ b/project/version.properties
@@ -1,1 +1,1 @@
-version=2.1.1-1
+version=2.1.2-msw

--- a/project/version.properties
+++ b/project/version.properties
@@ -1,1 +1,1 @@
-version=2.1.2-msw
+version=2.1.0

--- a/project/version.properties
+++ b/project/version.properties
@@ -1,1 +1,1 @@
-version=2.1.0
+version=2.1.1-1


### PR DESCRIPTION
Problem:

The app should be signaled somehow by op-rabbit about an unparsable item delivered by RabbitMQ in order to take specific actions.(e.g. raise specific service logs, increment specific stats etc..)

Solution:

To address this case we'd need a new directive in order to signal in invalid message(i.e. unparsable message) to the client code:

```
 bodyEither(as[JobDescription]) { jobDescriptionEither => // alarm the reason and take specific action

