### PR TITLE
Rabbitmq connection setup callback

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import java.util.Properties
 
 val json4sVersion = "3.6.6"
-val circeVersion = "0.12.0-M3"
+val circeVersion = "0.12.3"
 val akkaVersion = "2.5.25"
 val playVersion = "2.7.4"
 
@@ -16,7 +16,7 @@ val assertNoApplicationConf = taskKey[Unit]("Makes sure application.conf isn't p
 val commonSettings = Seq(
   organization := "com.spingo",
   version := appProperties.getProperty("version"),
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.12.10",
   crossScalaVersions := Seq("2.12.10", "2.13.1"),
   libraryDependencies ++= Seq(
     "com.chuusai" %%  "shapeless" % "2.3.3",

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import java.util.Properties
 
 val json4sVersion = "3.6.6"
-val circeVersion = "0.12.3"
+val circeVersion = "0.12.0-M3"
 val akkaVersion = "2.5.25"
 val playVersion = "2.7.4"
 
@@ -16,7 +16,7 @@ val assertNoApplicationConf = taskKey[Unit]("Makes sure application.conf isn't p
 val commonSettings = Seq(
   organization := "com.spingo",
   version := appProperties.getProperty("version"),
-  scalaVersion := "2.12.10",
+  scalaVersion := "2.11.8",
   crossScalaVersions := Seq("2.12.10", "2.13.1"),
   libraryDependencies ++= Seq(
     "com.chuusai" %%  "shapeless" % "2.3.3",

--- a/project/version.properties
+++ b/project/version.properties
@@ -1,1 +1,1 @@
-version=2.1.1-1
+version=2.1.2-msw

--- a/project/version.properties
+++ b/project/version.properties
@@ -1,1 +1,1 @@
-version=2.1.2-msw
+version=2.1.0

--- a/project/version.properties
+++ b/project/version.properties
@@ -1,1 +1,1 @@
-version=2.1.0
+version=2.1.1-1


### PR DESCRIPTION
Problem:

The `ConnectionActor` of the rabbitmq-client library offers the possibility to register a `connectionSetup` callback that is called every time it manages to connect to RabbitMQ. But op-rabbit currently does not expose such a `connectionSetup` callback in the `RabbitControl` constructor so it should as user's of op-rabbit should be allowed to register a `connectionSetup` callback in order to know when a connection goes up or down.





