### PR TITLE
Rabbitmq connection setup expose channel rpc timeout

### DIFF
--- a/core/src/main/scala/com/spingo/op_rabbit/ConnectionParams.scala
+++ b/core/src/main/scala/com/spingo/op_rabbit/ConnectionParams.scala
@@ -42,7 +42,8 @@ case class ConnectionParams(
   sharedExecutor: Option[java.util.concurrent.ExecutorService] = None,
   shutdownTimeout: Int = ConnectionFactory.DEFAULT_SHUTDOWN_TIMEOUT,
   socketFactory: SocketFactory = SocketFactory.getDefault,
-  sslContextOpt: Option[SSLContext] = None
+  sslContextOpt: Option[SSLContext] = None,
+  channelRpcTimeout: Int = ConnectionFactory.DEFAULT_CHANNEL_RPC_TIMEOUT
 ) {
   // TODO - eliminate ClusterConnectionFactory after switching to use RabbitMQ's topology recovery features.
   protected [op_rabbit] def applyTo(factory: ClusterConnectionFactory): Unit = {
@@ -71,6 +72,8 @@ case class ConnectionParams(
           factory.useSslProtocol()
       }
     }
+
+    factory.setChannelRpcTimeout(channelRpcTimeout)
   }
 }
 


### PR DESCRIPTION
Problem:

The AMQP drivers executes an AMQP command within a certain amount of time (i.e. ConnectionFactory.DEFAULT_CHANNEL_RPC_TIMEOUT). Op-rabbit should allow the op-rabbit user to set this timeout according to his needs. In order to achieve this `com.spingo.op_rabbit.ConnectionParams` should expose it in the last parameter of the constructor:

`channelRpcTimeout: Int = ConnectionFactory.DEFAULT_CHANNEL_RPC_TIMEOUT`

This also ensures backward compatibility.

@timcharper this is branched off rabbitmq-connection-setup-callback which is waiting for merge approval into master.


