### PR TITLE
Add jitpack.yml for building from jitpack.io.

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+install:
+  - sbt '+ publishM2'


### PR DESCRIPTION
This can help people download artifacts for any op-rabbit branch
or commit SHA and be able to use not-yet-released versions.