### PR TITLE
Remove deprecated API usage to support Akka 2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ import java.util.Properties
 
 val json4sVersion = "3.6.6"
 val circeVersion = "0.12.3"
-val akkaVersion = "2.5.25"
-val playVersion = "2.7.4"
+val akkaVersion = "2.6.6"
+val playVersion = "2.9.0"
 
 val appProperties = {
   val prop = new Properties()


### PR DESCRIPTION
Hi.

We noticed that op-rabbit uses an akka-streams API that got removed in Akka 2.6.
Currently this is hindering an update to Play 2.8 which brings in Akka 2.6.

I experimented with changing the akka-streams module to allow op-rabbit to be used
with 2.6 as well as 2.5. 

I created this pull request to discuss this - I do not expect it to be ready for merging.
Especially the akka-streams version should be downgraded to 2.5 - currently 2.6 to ensure
compatibility with it.

It would be great if you could have a look at it and provide me with some feedback about it. 
That would be very appreciated :)

Cheers
Carsten (and others)
